### PR TITLE
Restore GHC 7.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: haskell
 ghc:
   - 7.8
+  - 7.6

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Main where
 
@@ -47,7 +46,7 @@ main = defaultMain
     {-# INLINE unroll8 #-}
     unroll8 = Unroll
 
-bench_sum_foldl_LoopT :: Unrolling (UnLit n) => Unroll n -> Int -> Int
+bench_sum_foldl_LoopT :: Unrolling n => Unroll n -> Int -> Int
 {-# INLINE bench_sum_foldl_LoopT #-}
 bench_sum_foldl_LoopT unroll = \n -> foldl' (+) 0 $ loop $ for unroll 0 (<= n) (+ 1)
 
@@ -64,6 +63,6 @@ bench_sum_foldr_Vector :: Int -> Int
 bench_sum_foldr_Vector n =
     V.foldr (+) 0 $ V.enumFromTo 0 n
 
-bench_sum_foldr_LoopT :: Unrolling (UnLit n) => Unroll n -> Int -> Int
+bench_sum_foldr_LoopT :: Unrolling n => Unroll n -> Int -> Int
 {-# INLINE bench_sum_foldr_LoopT #-}
 bench_sum_foldr_LoopT unroll = \n -> foldr (+) 0 $ loop $ for unroll 0 (<= n) (+ 1)

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -47,7 +47,7 @@ main = defaultMain
     {-# INLINE unroll8 #-}
     unroll8 = Unroll
 
-bench_sum_foldl_LoopT :: Unrolling (UnTL n) => Unroll n -> Int -> Int
+bench_sum_foldl_LoopT :: Unrolling (UnLit n) => Unroll n -> Int -> Int
 {-# INLINE bench_sum_foldl_LoopT #-}
 bench_sum_foldl_LoopT unroll = \n -> foldl' (+) 0 $ loop $ for unroll 0 (<= n) (+ 1)
 
@@ -64,6 +64,6 @@ bench_sum_foldr_Vector :: Int -> Int
 bench_sum_foldr_Vector n =
     V.foldr (+) 0 $ V.enumFromTo 0 n
 
-bench_sum_foldr_LoopT :: Unrolling (UnTL n) => Unroll n -> Int -> Int
+bench_sum_foldr_LoopT :: Unrolling (UnLit n) => Unroll n -> Int -> Int
 {-# INLINE bench_sum_foldr_LoopT #-}
 bench_sum_foldr_LoopT unroll = \n -> foldr (+) 0 $ loop $ for unroll 0 (<= n) (+ 1)

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-
 module Main where
 
 import Criterion.Main
@@ -15,7 +13,7 @@ main = defaultMain
         [ bgroup "foldl"
             [ bench "[]" $ nf bench_sum_foldl_List iters
             , bench "Vector" $ nf bench_sum_foldl_Vector iters
-            , bench "Loop 1" $ nf (bench_sum_foldl_LoopT noUnroll) iters
+            , bench "Loop 1" $ nf (bench_sum_foldl_LoopT unroll1) iters
             , bench "Loop 2" $ nf (bench_sum_foldl_LoopT unroll2) iters
             , bench "Loop 4" $ nf (bench_sum_foldl_LoopT unroll4) iters
             , bench "Loop 8" $ nf (bench_sum_foldl_LoopT unroll8) iters
@@ -23,7 +21,7 @@ main = defaultMain
         , bgroup "foldr"
             [ bench "[]" $ nf bench_sum_foldr_List iters
             , bench "Vector" $ nf bench_sum_foldr_Vector iters
-            , bench "Loop 1" $ nf (bench_sum_foldr_LoopT noUnroll) iters
+            , bench "Loop 1" $ nf (bench_sum_foldr_LoopT unroll1) iters
             , bench "Loop 2" $ nf (bench_sum_foldr_LoopT unroll2) iters
             , bench "Loop 4" $ nf (bench_sum_foldr_LoopT unroll4) iters
             , bench "Loop 8" $ nf (bench_sum_foldr_LoopT unroll8) iters
@@ -33,18 +31,6 @@ main = defaultMain
   where
     iters :: Int
     iters = 10000000
-
-    unroll2 :: Unroll 2
-    {-# INLINE unroll2 #-}
-    unroll2 = Unroll
-
-    unroll4 :: Unroll 4
-    {-# INLINE unroll4 #-}
-    unroll4 = Unroll
-
-    unroll8 :: Unroll 8
-    {-# INLINE unroll8 #-}
-    unroll8 = Unroll
 
 bench_sum_foldl_LoopT :: Unrolling n => Unroll n -> Int -> Int
 {-# INLINE bench_sum_foldl_LoopT #-}

--- a/loops.cabal
+++ b/loops.cabal
@@ -32,7 +32,7 @@ category:            Control
 build-type:          Simple
 extra-source-files:  README.md, README.lhs
 cabal-version:       >=1.10
-tested-with:         GHC == 7.8.2
+tested-with:         GHC == 7.6.3, GHC == 7.8.2
 
 source-repository head
   type: git

--- a/loops.cabal
+++ b/loops.cabal
@@ -40,6 +40,7 @@ source-repository head
 
 library
   exposed-modules:
+    Data.Unroll
     Control.Monad.Loop
     Control.Monad.Loop.Unroll
     Control.Monad.Loop.ForEach

--- a/src/Control/Monad/Loop.hs
+++ b/src/Control/Monad/Loop.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module Control.Monad.Loop
     ( LoopT(..), Loop, loop
     , cons, continue, continue_, break, break_, exec_
+#if __GLASGOW_HASKELL >= 708
     , ForEach(ForEachValue, ForEachIx)
+#else
+    , ForEach(), ForEachValue, ForEachIx
+#endif
     , iterate, forever, for, unfoldl, while
     , forEach, iforEach
     ) where
@@ -9,8 +15,12 @@ module Control.Monad.Loop
 import Control.Monad.Loop.Unroll
     ( LoopT(..), Loop, loop
     , cons, continue, continue_, break, break_, exec_
+#if __GLASGOW_HASKELL >= 708
     , ForEach(ForEachValue, ForEachIx)
-    , noUnroll
+#else
+    , ForEach(), ForEachValue, ForEachIx
+#endif
+    , unroll1
     )
 import qualified Control.Monad.Loop.Unroll as U
 import Prelude hiding (break, iterate)
@@ -20,11 +30,11 @@ iterate
     -> (a -> a)   -- ^ Advance the iterator
     -> LoopT m a
 {-# INLINE iterate #-}
-iterate = U.iterate noUnroll
+iterate = U.iterate unroll1
 
 forever :: LoopT m ()
 {-# INLINE forever #-}
-forever = U.forever noUnroll
+forever = U.forever unroll1
 
 for
     :: a            -- ^ Starting value of iterator
@@ -34,7 +44,7 @@ for
     -> (a -> a)     -- ^ Advance the iterator
     -> LoopT m a
 {-# INLINE for #-}
-for = U.for noUnroll
+for = U.for unroll1
 
 unfoldl
     :: (i -> Maybe (i, a))  -- ^ @Just (i, a)@ advances the loop, yielding an
@@ -42,21 +52,21 @@ unfoldl
     -> i                    -- ^ Starting value
     -> LoopT m a
 {-# INLINE unfoldl #-}
-unfoldl = U.unfoldl noUnroll
+unfoldl = U.unfoldl unroll1
 
 while
     :: Monad m
     => m Bool
     -> LoopT m ()
 {-# INLINE while #-}
-while = U.while noUnroll
+while = U.while unroll1
 
 -- | Iterate over the values in the container.
 forEach :: ForEach m c => c -> m (ForEachValue c)
 {-# INLINE forEach #-}
-forEach = U.forEach noUnroll
+forEach = U.forEach unroll1
 
 -- | Iterate over the indices and the value at each index.
 iforEach :: ForEach m c => c -> m (ForEachIx c, ForEachValue c)
 {-# INLINE iforEach #-}
-iforEach = U.iforEach noUnroll
+iforEach = U.iforEach unroll1

--- a/src/Control/Monad/Loop/ForEach.hs
+++ b/src/Control/Monad/Loop/ForEach.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Control.Monad.Loop.ForEach where
+module Control.Monad.Loop.ForEach (ForEach(..)) where
 
 import Control.Monad (liftM)
 import Control.Monad.Primitive (PrimMonad, PrimState)

--- a/src/Control/Monad/Loop/ForEach.hs
+++ b/src/Control/Monad/Loop/ForEach.hs
@@ -32,9 +32,9 @@ class ForEach m c where
     type ForEachValue c
     type ForEachIx c
     -- | Iterate over the values in the container.
-    forEach :: Unrolling (UnTL n) => Unroll n -> c -> m (ForEachValue c)
+    forEach :: Unrolling (UnLit n) => Unroll n -> c -> m (ForEachValue c)
     -- | Iterate over the indices and the value at each index.
-    iforEach :: Unrolling (UnTL n) => Unroll n -> c -> m (ForEachIx c, ForEachValue c)
+    iforEach :: Unrolling (UnLit n) => Unroll n -> c -> m (ForEachIx c, ForEachValue c)
 
 instance (Monad m) => ForEach (LoopT m) [a] where
     type ForEachValue [a] = a
@@ -78,11 +78,11 @@ instance (Monad m, S.Storable a) => ForEach (LoopT m) (S.Vector a) where
     {-# INLINE forEach #-}
     {-# INLINE iforEach #-}
 
-forEachVector :: (Monad m, G.Vector v a, Unrolling (UnTL n)) => Unroll n -> v a -> LoopT m a
+forEachVector :: (Monad m, G.Vector v a, Unrolling (UnLit n)) => Unroll n -> v a -> LoopT m a
 {-# INLINE forEachVector #-}
 forEachVector unroll = liftM snd . iforEachVector unroll
 
-iforEachVector :: (Monad m, G.Vector v a, Unrolling (UnTL n)) => Unroll n -> v a -> LoopT m (Int, a)
+iforEachVector :: (Monad m, G.Vector v a, Unrolling (UnLit n)) => Unroll n -> v a -> LoopT m (Int, a)
 {-# INLINE iforEachVector #-}
 iforEachVector unroll = \v -> do
     let len = G.length v
@@ -122,11 +122,11 @@ instance (S.Storable a, PrimMonad m, PrimState m ~ s) => ForEach (LoopT m) (MS.M
     {-# INLINE forEach #-}
     {-# INLINE iforEach #-}
 
-forEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling (UnTL n)) => Unroll n -> v (PrimState m) a -> LoopT m a
+forEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling (UnLit n)) => Unroll n -> v (PrimState m) a -> LoopT m a
 {-# INLINE forEachMVector #-}
 forEachMVector unroll = liftM snd . iforEachMVector unroll
 
-iforEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling (UnTL n)) => Unroll n -> v (PrimState m) a -> LoopT m (Int, a)
+iforEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling (UnLit n)) => Unroll n -> v (PrimState m) a -> LoopT m (Int, a)
 {-# INLINE iforEachMVector #-}
 iforEachMVector unroll = \v -> do
     let len = MG.length v

--- a/src/Control/Monad/Loop/ForEach.hs
+++ b/src/Control/Monad/Loop/ForEach.hs
@@ -32,9 +32,9 @@ class ForEach m c where
     type ForEachValue c
     type ForEachIx c
     -- | Iterate over the values in the container.
-    forEach :: Unrolling (UnLit n) => Unroll n -> c -> m (ForEachValue c)
+    forEach :: Unrolling n => Unroll n -> c -> m (ForEachValue c)
     -- | Iterate over the indices and the value at each index.
-    iforEach :: Unrolling (UnLit n) => Unroll n -> c -> m (ForEachIx c, ForEachValue c)
+    iforEach :: Unrolling n => Unroll n -> c -> m (ForEachIx c, ForEachValue c)
 
 instance (Monad m) => ForEach (LoopT m) [a] where
     type ForEachValue [a] = a
@@ -78,11 +78,11 @@ instance (Monad m, S.Storable a) => ForEach (LoopT m) (S.Vector a) where
     {-# INLINE forEach #-}
     {-# INLINE iforEach #-}
 
-forEachVector :: (Monad m, G.Vector v a, Unrolling (UnLit n)) => Unroll n -> v a -> LoopT m a
+forEachVector :: (Monad m, G.Vector v a, Unrolling n) => Unroll n -> v a -> LoopT m a
 {-# INLINE forEachVector #-}
 forEachVector unroll = liftM snd . iforEachVector unroll
 
-iforEachVector :: (Monad m, G.Vector v a, Unrolling (UnLit n)) => Unroll n -> v a -> LoopT m (Int, a)
+iforEachVector :: (Monad m, G.Vector v a, Unrolling n) => Unroll n -> v a -> LoopT m (Int, a)
 {-# INLINE iforEachVector #-}
 iforEachVector unroll = \v -> do
     let len = G.length v
@@ -122,11 +122,11 @@ instance (S.Storable a, PrimMonad m, PrimState m ~ s) => ForEach (LoopT m) (MS.M
     {-# INLINE forEach #-}
     {-# INLINE iforEach #-}
 
-forEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling (UnLit n)) => Unroll n -> v (PrimState m) a -> LoopT m a
+forEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling n) => Unroll n -> v (PrimState m) a -> LoopT m a
 {-# INLINE forEachMVector #-}
 forEachMVector unroll = liftM snd . iforEachMVector unroll
 
-iforEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling (UnLit n)) => Unroll n -> v (PrimState m) a -> LoopT m (Int, a)
+iforEachMVector :: (PrimMonad m, MG.MVector v a, Unrolling n) => Unroll n -> v (PrimState m) a -> LoopT m (Int, a)
 {-# INLINE iforEachMVector #-}
 iforEachMVector unroll = \v -> do
     let len = MG.length v

--- a/src/Control/Monad/Loop/Internal.hs
+++ b/src/Control/Monad/Loop/Internal.hs
@@ -1,11 +1,6 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Control.Monad.Loop.Internal
     ( LoopT(..), Loop, loop
@@ -19,12 +14,13 @@ import Control.Category ((<<<), (>>>))
 import Control.Monad (unless)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import qualified GHC.TypeLits as TL
 import Data.Foldable
 import Data.Functor.Identity
 import Data.Maybe (fromJust, isJust)
 import Data.Traversable (Traversable(..))
 import Prelude hiding (foldr, iterate, break)
+
+import Data.Unroll
 
 -- | @LoopT m a@ represents a loop over a base type @m@ that yields a value
 -- @a@ at each iteration. It can be used as a monad transformer, but there
@@ -125,24 +121,24 @@ exec_ xs = runLoopT xs (\_ next _ -> next) (pure ()) (pure ())
 
 -- | Iterate forever (or until 'break' is used).
 iterate
-    :: Unrolling (UnTL n)
+    :: Unrolling (UnLit n)
     => Unroll n   -- ^ Unrolling factor
     -> a          -- ^ Starting value of iterator
     -> (a -> a)   -- ^ Advance the iterator
     -> LoopT m a
 {-# INLINE iterate #-}
 iterate unroll = \a0 adv -> LoopT $ \yield next _ ->
-    let go a = unrollIterate (fromTypeLit unroll) a adv yield go next
+    let go a = unrollIterate (unlit unroll) a adv yield go next
     in go a0
 
 -- | Loop forever without yielding (interesting) values.
-forever :: Unrolling (UnTL n) => Unroll n -> LoopT m ()
+forever :: Unrolling (UnLit n) => Unroll n -> LoopT m ()
 {-# INLINE forever #-}
 forever unroll = iterate unroll () id
 
 -- | Standard @for@ loop.
 for
-    :: Unrolling (UnTL n)
+    :: Unrolling (UnLit n)
     => Unroll n     -- ^ Unrolling factor
     -> a            -- ^ Starting value of iterator
     -> (a -> Bool)  -- ^ Termination condition. The loop will terminate the
@@ -152,12 +148,12 @@ for
     -> LoopT m a
 {-# INLINE for #-}
 for unroll = \a0 cond adv -> LoopT $ \yield next _ ->
-    let go a = unrollFor (fromTypeLit unroll) a cond adv yield go next
+    let go a = unrollFor (unlit unroll) a cond adv yield go next
     in if cond a0 then go a0 else next
 
 -- | Unfold a loop from the left.
 unfoldl
-    :: Unrolling (UnTL n)
+    :: Unrolling (UnLit n)
     => Unroll n             -- ^ Unrolling factor
     -> (i -> Maybe (i, a))  -- ^ @Just (i, a)@ advances the loop, yielding an
                             -- @a@. @Nothing@ terminates the loop.
@@ -168,7 +164,7 @@ unfoldl unroll = \unf i0 ->
     fromJust . fmap snd <$> for unroll (unf i0) isJust (>>= unf . fst)
 
 while
-    :: (Unrolling (UnTL n), Monad m)
+    :: (Unrolling (UnLit n), Monad m)
     => Unroll n
     -> m Bool
     -> LoopT m ()
@@ -177,57 +173,3 @@ while unroll = \cond -> do
     forever unroll
     p <- lift cond
     unless p break_
-
--- | Proxy type for GHC's type level literal natural numbers. @n@ is the
--- number of times the loop will be unrolled into its own body.
-data Unroll (n :: TL.Nat) = Unroll
-
-data Nat = S !Nat | Z
-data UnrollInd (n :: Nat) = UnrollInd
-
--- | Do not unroll the loop at all.
-noUnroll :: Unroll 1
-noUnroll = Unroll
-
-predUnroll :: UnrollInd (S n) -> UnrollInd n
-predUnroll UnrollInd = UnrollInd
-
-type family UnTL (n :: TL.Nat) :: Nat where
-    UnTL 1 = S Z
-    UnTL n = S (UnTL ((TL.-) n 1))
-
-fromTypeLit :: Unroll n -> UnrollInd (UnTL n)
-fromTypeLit Unroll = UnrollInd
-
-class Unrolling (n :: Nat) where
-    unrollFor
-        :: UnrollInd n
-        -> a -> (a -> Bool) -> (a -> a)  -- for parameters
-        -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
-
-    unrollIterate
-        :: UnrollInd n  -- unrolling factor
-        -> a -> (a -> a)  -- iterate parameters
-        -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
-
-instance Unrolling Z where
-    {-# INLINE unrollFor #-}
-    unrollFor UnrollInd a _ _ _ next _ = next a
-
-    {-# INLINE unrollIterate #-}
-    unrollIterate UnrollInd a _ _ next _ = next a
-
-instance Unrolling n => Unrolling (S n) where
-    {-# INLINE unrollFor #-}
-    unrollFor unroll a cond adv yield next brk =
-        yield a descend brk
-      where
-        a' = adv a
-        descend | cond a' = unrollFor (predUnroll unroll) a' cond adv yield next brk
-                | otherwise = brk
-
-    {-# INLINE unrollIterate #-}
-    unrollIterate unroll a adv yield next brk =
-        yield a descend brk
-      where
-        descend = unrollIterate (predUnroll unroll) (adv a) adv yield next brk

--- a/src/Control/Monad/Loop/Internal.hs
+++ b/src/Control/Monad/Loop/Internal.hs
@@ -2,9 +2,9 @@
 
 module Control.Monad.Loop.Internal
     ( LoopT(..), Loop, loop
-    , Unroll(..), Unrolling(), noUnroll
     , cons, continue, continue_, break, break_, exec_
     , iterate, forever, for, unfoldl, while
+    , module Data.Unroll
     ) where
 
 import Control.Applicative (Applicative(..), (<$>), liftA2)

--- a/src/Data/Unroll.hs
+++ b/src/Data/Unroll.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DataKinds, KindSignatures #-}
+{-# LANGUAGE TypeFamilies, UndecidableInstances #-}
+
+module Data.Unroll where
+
+import GHC.TypeLits
+
+-- | Proxy type for GHC's type level literal natural numbers. @n@ is the
+-- number of times the loop will be unrolled into its own body.
+data Unroll (n :: Nat) = Unroll
+
+data INat = S !INat | Z
+data IUnroll (n :: INat) = IUnroll
+
+-- | Do not unroll the loop at all.
+noUnroll :: Unroll 1
+noUnroll = Unroll
+
+predUnroll :: IUnroll (S n) -> IUnroll n
+predUnroll IUnroll = IUnroll
+
+type family UnLit (n :: Nat) :: INat where
+    UnLit 1 = S Z
+    UnLit n = S (UnLit ((-) n 1))
+
+unlit :: Unroll n -> IUnroll (UnLit n)
+unlit Unroll = IUnroll
+
+class Unrolling (n :: INat) where
+    unrollFor
+        :: IUnroll n
+        -> a -> (a -> Bool) -> (a -> a)  -- for parameters
+        -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
+
+    unrollIterate
+        :: IUnroll n  -- unrolling factor
+        -> a -> (a -> a)  -- iterate parameters
+        -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
+
+instance Unrolling Z where
+    {-# INLINE unrollFor #-}
+    unrollFor IUnroll a _ _ _ next _ = next a
+
+    {-# INLINE unrollIterate #-}
+    unrollIterate IUnroll a _ _ next _ = next a
+
+instance Unrolling n => Unrolling (S n) where
+    {-# INLINE unrollFor #-}
+    unrollFor unroll a cond adv yield next brk =
+        yield a descend brk
+      where
+        a' = adv a
+        descend | cond a' = unrollFor (predUnroll unroll) a' cond adv yield next brk
+                | otherwise = brk
+
+    {-# INLINE unrollIterate #-}
+    unrollIterate unroll a adv yield next brk =
+        yield a descend brk
+      where
+        descend = unrollIterate (predUnroll unroll) (adv a) adv yield next brk

--- a/src/Data/Unroll.hs
+++ b/src/Data/Unroll.hs
@@ -1,23 +1,59 @@
 {-# LANGUAGE DataKinds, KindSignatures #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies, UndecidableInstances #-}
 
 module Data.Unroll where
 
 import GHC.TypeLits
 
--- | Proxy type for GHC's type level literal natural numbers. @n@ is the
--- number of times the loop will be unrolled into its own body.
-data Unroll (n :: Nat) = Unroll
+-- Unrolling by induction
+-- Can't use GHC's type level literals here, they don't support induction
 
 data INat = S !INat | Z
 data IUnroll (n :: INat) = IUnroll
 
--- | Do not unroll the loop at all.
-noUnroll :: Unroll 1
-noUnroll = Unroll
-
 predUnroll :: IUnroll (S n) -> IUnroll n
 predUnroll IUnroll = IUnroll
+
+class IUnrolling (n :: INat) where
+    iUnrollFor
+        :: IUnroll n
+        -> a -> (a -> Bool) -> (a -> a)  -- for parameters
+        -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
+
+    iUnrollIterate
+        :: IUnroll n  -- unrolling factor
+        -> a -> (a -> a)  -- iterate parameters
+        -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
+
+instance IUnrolling Z where
+    {-# INLINE iUnrollFor #-}
+    iUnrollFor IUnroll a _ _ _ next _ = next a
+
+    {-# INLINE iUnrollIterate #-}
+    iUnrollIterate IUnroll a _ _ next _ = next a
+
+instance IUnrolling n => IUnrolling (S n) where
+    {-# INLINE iUnrollFor #-}
+    iUnrollFor unroll a cond adv yield next brk =
+        yield a descend brk
+      where
+        a' = adv a
+        descend | cond a' = iUnrollFor (predUnroll unroll) a' cond adv yield next brk
+                | otherwise = brk
+
+    {-# INLINE iUnrollIterate #-}
+    iUnrollIterate unroll a adv yield next brk =
+        yield a descend brk
+      where
+        descend = iUnrollIterate (predUnroll unroll) (adv a) adv yield next brk
+
+-- Unrolling using type level literals
+-- Just a clean wrapper around the inductive code above
+
+-- | Proxy type for GHC's type level literal natural numbers. @n@ is the
+-- number of times the loop will be unrolled into its own body.
+data Unroll (n :: Nat) = Unroll
 
 type family UnLit (n :: Nat) :: INat where
     UnLit 1 = S Z
@@ -26,35 +62,23 @@ type family UnLit (n :: Nat) :: INat where
 unlit :: Unroll n -> IUnroll (UnLit n)
 unlit Unroll = IUnroll
 
-class Unrolling (n :: INat) where
+-- | Do not unroll the loop at all.
+noUnroll :: Unroll 1
+noUnroll = Unroll
+
+class IUnrolling (UnLit n) => Unrolling (n :: Nat) where
     unrollFor
-        :: IUnroll n
+        :: Unroll n
         -> a -> (a -> Bool) -> (a -> a)  -- for parameters
         -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
+    {-# INLINE unrollFor #-}
+    unrollFor = iUnrollFor . unlit
 
     unrollIterate
-        :: IUnroll n  -- unrolling factor
+        :: Unroll n  -- unrolling factor
         -> a -> (a -> a)  -- iterate parameters
         -> (a -> m r -> m r -> m r) -> (a -> m r) -> m r -> m r  -- un-newtyped LoopT
-
-instance Unrolling Z where
-    {-# INLINE unrollFor #-}
-    unrollFor IUnroll a _ _ _ next _ = next a
-
     {-# INLINE unrollIterate #-}
-    unrollIterate IUnroll a _ _ next _ = next a
+    unrollIterate = iUnrollIterate . unlit
 
-instance Unrolling n => Unrolling (S n) where
-    {-# INLINE unrollFor #-}
-    unrollFor unroll a cond adv yield next brk =
-        yield a descend brk
-      where
-        a' = adv a
-        descend | cond a' = unrollFor (predUnroll unroll) a' cond adv yield next brk
-                | otherwise = brk
-
-    {-# INLINE unrollIterate #-}
-    unrollIterate unroll a adv yield next brk =
-        yield a descend brk
-      where
-        descend = unrollIterate (predUnroll unroll) (adv a) adv yield next brk
+instance IUnrolling (UnLit n) => Unrolling n

--- a/src/Data/Unroll.hs
+++ b/src/Data/Unroll.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds, KindSignatures #-}
 {-# LANGUAGE FlexibleContexts, FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies, UndecidableInstances #-}
 
-module Data.Unroll where
+module Data.Unroll
+    ( Nat, N1, N2, N4, N8
+    , Unroll(..), unroll1, unroll2, unroll4, unroll8
+    , Unrolling(..)
+    ) where
 
+#if __GLASGOW_HASKELL__ >= 708
 import GHC.TypeLits
+#endif
 
 -- Unrolling by induction
 -- Can't use GHC's type level literals here, they don't support induction
@@ -51,22 +58,57 @@ instance IUnrolling n => IUnrolling (S n) where
 -- Unrolling using type level literals
 -- Just a clean wrapper around the inductive code above
 
--- | Proxy type for GHC's type level literal natural numbers. @n@ is the
--- number of times the loop will be unrolled into its own body.
-data Unroll (n :: Nat) = Unroll
+#if __GLASGOW_HASKELL__ < 708
+type Nat = INat
+type N1 = S Z
+type N2 = S N1
+type N4 = S (S N2)
+type N8 = S (S (S (S N4)))
+#else
+type N1 = 1
+type N2 = 2
+type N4 = 3
+type N8 = 4
+#endif
 
+-- | Proxy type for natural numbers. @n@ is the number of times the loop
+-- will be unrolled into its own body. @n@ must be at least @1@, or the
+-- loop would have no body at all!
+#if __GLASGOW_HASKELL__ >= 708
+data Unroll (n :: Nat) = Unroll
+#else
+data Unroll (n :: INat) = Unroll
+#endif
+
+#if __GLASGOW_HASKELL__ >= 708
 type family UnLit (n :: Nat) :: INat where
     UnLit 1 = S Z
     UnLit n = S (UnLit ((-) n 1))
+#else
+type UnLit (n :: INat) = n
+#endif
 
 unlit :: Unroll n -> IUnroll (UnLit n)
 unlit Unroll = IUnroll
 
 -- | Do not unroll the loop at all.
-noUnroll :: Unroll 1
-noUnroll = Unroll
+unroll1 :: Unroll N1
+unroll1 = Unroll
 
+unroll2 :: Unroll N2
+unroll2 = Unroll
+
+unroll4 :: Unroll N4
+unroll4 = Unroll
+
+unroll8 :: Unroll N8
+unroll8 = Unroll
+
+#if __GLASGOW_HASKELL__ >= 708
 class IUnrolling (UnLit n) => Unrolling (n :: Nat) where
+#else
+class IUnrolling (UnLit n) => Unrolling (n :: INat) where
+#endif
     unrollFor
         :: Unroll n
         -> a -> (a -> Bool) -> (a -> a)  -- for parameters

--- a/test/Test/Sum.hs
+++ b/test/Test/Sum.hs
@@ -2,42 +2,37 @@
 
 module Test.Sum where
 
-import qualified Control.Monad.Loop as LoopT
-import qualified Control.Monad.Loop.Unroll as Unroll
+import Control.Monad.Loop.Unroll
 import Data.Foldable
 import Prelude hiding (foldr)
 import Test.Tasty.QuickCheck
 
 prop_sum_foldl_LoopT :: [Int] -> Property
 prop_sum_foldl_LoopT xs =
-    foldl' (+) 0 xs === foldl' (+) 0 (LoopT.forEach xs :: LoopT.Loop Int)
+    foldl' (+) 0 xs === (foldl' (+) 0 $ loop $ forEach unroll1 xs)
 
 prop_sum_foldr_LoopT :: [Int] -> Property
 prop_sum_foldr_LoopT xs =
-    foldr (+) 0 xs === foldr (+) 0 (LoopT.forEach xs :: LoopT.Loop Int)
+    foldr (+) 0 xs === (foldr (+) 0 $ loop $ forEach unroll1 xs)
 
 prop_sum_foldl_LoopT_Unroll :: [Int] -> Property
 prop_sum_foldl_LoopT_Unroll xs =
-    foldl' (+) 0 xs === foldl' (+) 0 (Unroll.forEach unroll xs :: Unroll.Loop Int)
-  where
-    unroll :: Unroll.Unroll 8
-    unroll = Unroll.Unroll
+    foldl' (+) 0 xs === (foldl' (+) 0 $ loop $ forEach unroll8 xs)
 
 prop_sum_foldr_LoopT_Unroll :: [Int] -> Property
 prop_sum_foldr_LoopT_Unroll xs =
-    foldr (+) 0 xs === foldr (+) 0 (Unroll.forEach unroll xs :: Unroll.Loop Int)
-  where
-    unroll :: Unroll.Unroll 8
-    unroll = Unroll.Unroll
+    foldr (+) 0 xs === (foldr (+) 0 $ loop $ forEach unroll8 xs)
 
 prop_break_order :: [Int] -> Property
 prop_break_order xs =
     foldl' (+) 0 before === foldl' (+) 0 after
   where
-    before = LoopT.loop $ do
-      x <- LoopT.forEach xs
-      if x < 10 then LoopT.continue 10 else LoopT.break_
-    after = LoopT.loop $ do
-      x <- LoopT.forEach xs
+    before :: Loop Int
+    before = loop $ do
+      x <- forEach unroll1 xs
+      if x < 10 then continue 10 else break_
+    after :: Loop Int
+    after = loop $ do
+      x <- forEach unroll1 xs
       return ()
-      if x < 10 then LoopT.continue 10 else LoopT.break_
+      if x < 10 then continue 10 else break_


### PR DESCRIPTION
There were two main problems with supporting GHC 7.6:
- Although `DataKinds` are supported, there are no closed type families, so `UnLit` is out. That means the class `Unrolling` must take an `INat` (inductive natural number) rather than a type-level literal `Nat`. The `CPP` for this is contained within `Data.Unroll`.
- GHC 7.6 doesn't consider associated type families to be members of their associated classes for import lists, so they must be imported differently.

(This pull request is just to check on Travis.)
